### PR TITLE
fix CircleCI configuration and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
 
 COPY . /src/muffnn
 RUN conda env create -f /src/muffnn/environment.yml -q
-RUN conda install flake8 pytest pip nose -n muffnn && \  # testing deps
+RUN conda install flake8 pytest pip nose -n muffnn && \
     pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.10.0rc0-cp35-cp35m-linux_x86_64.whl
 RUN cd /src/muffnn && \
     pip install .

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,6 @@ machine:
 dependencies:
   override:
     - docker info
-    - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
     - docker build -t civisanalytics/muffnn .
 
 test:


### PR DESCRIPTION
We don't need the docker login step since there are no private dockerhub dependencies.
