### PR TITLE
In which we add functionality that was previously added in the private repo but was mistakenly not included in the public version

### DIFF
--- a/muffnn/mlp/base.py
+++ b/muffnn/mlp/base.py
@@ -44,7 +44,7 @@ class MLPBaseEstimator(TFPicklingBase, BaseEstimator, metaclass=ABCMeta):
         # fitting a classifier.
         return y
 
-    def fit(self, X, y):
+    def fit(self, X, y, monitor=None):
         """Fit the model.
 
         Parameters
@@ -53,6 +53,15 @@ class MLPBaseEstimator(TFPicklingBase, BaseEstimator, metaclass=ABCMeta):
             Training data
         y : numpy array of shape [n_samples, n_targets]
             Target values
+        monitor : callable, optional
+            The monitor is called after each iteration with the current
+            iteration, a reference to the estimator, and a dictionary with
+            {'loss': loss_value} representing the loss calculated by the
+            objective function at this iteration.
+            If the callable returns True the fitting procedure is stopped.
+            The monitor can be used for various things such as computing
+            held-out estimates, early stopping, model introspection,
+            and snapshoting.
 
         Returns
         -------
@@ -65,14 +74,14 @@ class MLPBaseEstimator(TFPicklingBase, BaseEstimator, metaclass=ABCMeta):
         self._is_fitted = False
 
         # Call partial fit, which will initialize and then train the model.
-        return self.partial_fit(X, y)
+        return self.partial_fit(X, y, monitor=monitor)
 
     def _fit_targets(self, y):
         # This can be overwritten to set instance variables that pertain to the
         # targets (e.g., an array of class labels).
         pass
 
-    def partial_fit(self, X, y, **kwargs):
+    def partial_fit(self, X, y, monitor=None, **kwargs):
         """Fit the model on a batch of training data.
 
         Parameters
@@ -81,6 +90,15 @@ class MLPBaseEstimator(TFPicklingBase, BaseEstimator, metaclass=ABCMeta):
             Training data
         y : numpy array of shape [n_samples, n_targets]
             Target values
+        monitor : callable, optional
+            The monitor is called after each iteration with the current
+            iteration, a reference to the estimator, and a dictionary with
+            {'loss': loss_value} representing the loss calculated by the
+            objective function at this iteration.
+            If the callable returns True the fitting procedure is stopped.
+            The monitor can be used for various things such as computing
+            held-out estimates, early stopping, model introspection,
+            and snapshoting.
 
         Returns
         -------
@@ -124,26 +142,30 @@ class MLPBaseEstimator(TFPicklingBase, BaseEstimator, metaclass=ABCMeta):
         # Train the model with the given data.
         with self.graph_.as_default():
             n_examples = X.shape[0]
-            start_idx = 0
-            epoch = 0
             indices = np.arange(n_examples)
             random_state.shuffle(indices)
 
-            while True:
-                batch_ind = indices[start_idx:start_idx + self.batch_size]
-                feed_dict = self._make_feed_dict(X[batch_ind],
-                                                 y[batch_ind])
-                obj_val, _ = self._session.run(
-                    [self._obj_func, self._train_step], feed_dict=feed_dict)
+            for epoch in range(self.n_epochs):
+                random_state.shuffle(indices)
+                for start_idx in range(0, n_examples, self.batch_size):
+                    batch_ind = indices[start_idx:start_idx + self.batch_size]
+                    feed_dict = self._make_feed_dict(X[batch_ind],
+                                                     y[batch_ind])
+                    obj_val, _ = self._session.run(
+                        [self._obj_func, self._train_step],
+                        feed_dict=feed_dict)
+                    _LOGGER.debug("objective: %.4f, epoch: %d, idx: %d",
+                                  obj_val, epoch, start_idx)
+
                 _LOGGER.info("objective: %.4f, epoch: %d, idx: %d",
                              obj_val, epoch, start_idx)
-                start_idx += self.batch_size
-                if start_idx > n_examples - self.batch_size:
-                    start_idx = 0
-                    epoch += 1
-                    if epoch >= self.n_epochs:
-                        break
-                    random_state.shuffle(indices)
+
+                if monitor:
+                    stop_early = monitor(epoch, self, {'loss': obj_val})
+                    if stop_early:
+                        _LOGGER.info(
+                            "stopping early due to monitor function.")
+                        return self
 
         return self
 

--- a/muffnn/mlp/mlp_classifier.py
+++ b/muffnn/mlp/mlp_classifier.py
@@ -88,9 +88,9 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
         n_classes = len(self.classes_)
 
         if self.multilabel_:
-            output_size = n_classes
-        elif n_classes > 2:
-            output_size = n_classes
+            output_size = self.n_classes_
+        elif self.n_classes_ > 2:
+            output_size = self.n_classes_
         else:
             output_size = 1
 
@@ -103,9 +103,9 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
 
         if self.multilabel_:
             self.input_targets_ = \
-                tf.placeholder(tf.int64, [None, n_classes], "targets")
+                tf.placeholder(tf.int64, [None, self.n_classes_], "labels")
             self.output_layer_ = tf.nn.sigmoid(t)
-        elif n_classes > 2:
+        elif self.n_classes_ > 2:
             self.input_targets_ = tf.placeholder(tf.int64, [None], "targets")
             self.output_layer_ = tf.nn.softmax(t)
         else:
@@ -115,11 +115,10 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
         return t
 
     def _init_model_objective_fn(self, t):
-        n_classes = len(self.classes_)
         if self.multilabel_:
             cross_entropy = tf.nn.sigmoid_cross_entropy_with_logits(
                 t, tf.cast(self.input_targets_, np.float32))
-        elif n_classes > 2:
+        elif self.n_classes_ > 2:
             cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(
                 t, self.input_targets_)
         else:
@@ -179,9 +178,11 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
         if self.multilabel_:
             self._enc = None
             self.classes_ = np.array([0, 1])
+            self.n_classes_ = y.shape[1]
         else:
             self._enc = LabelEncoder().fit(y)
             self.classes_ = self._enc.classes_
+            self.n_classes_ = len(self.classes_)
 
     def _transform_targets(self, y):
         return y if self.multilabel_ else self._enc.transform(y)
@@ -240,5 +241,6 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
             state['_enc'] = self.classes_
             state['classes_'] = self.classes_
             state['multilabel_'] = self.multilabel_
+            state['n_classes_'] = self.n_classes_
 
         return state

--- a/muffnn/mlp/mlp_classifier.py
+++ b/muffnn/mlp/mlp_classifier.py
@@ -85,7 +85,6 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
         self.random_state = random_state
 
     def _init_model_output(self, t):
-        n_classes = len(self.classes_)
 
         if self.multilabel_:
             output_size = self.n_classes_

--- a/muffnn/mlp/mlp_classifier.py
+++ b/muffnn/mlp/mlp_classifier.py
@@ -126,7 +126,7 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
                 t, tf.cast(self.input_targets_, np.float32))
         self._obj_func = tf.reduce_mean(cross_entropy)
 
-    def partial_fit(self, X, y, classes=None):
+    def partial_fit(self, X, y, monitor=None, classes=None):
         """Fit the model on a batch of training data.
 
         Parameters
@@ -139,6 +139,15 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
             Classes to be used across calls to partial_fit.  If not set in the
             first call, it will be inferred from the given targets. If
             subsequent calls include additional classes, they will fail.
+        monitor : callable, optional
+            The monitor is called after each iteration with the current
+            iteration, a reference to the estimator, and a dictionary with
+            {'loss': loss_value} representing the loss calculated by the
+            objective function at this iteration.
+            If the callable returns True the fitting procedure is stopped.
+            The monitor can be used for various things such as computing
+            held-out estimates, early stopping, model introspection,
+            and snapshoting.
 
         Returns
         -------
@@ -149,7 +158,7 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
         This is based on
         http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDClassifier.html
         """
-        return super().partial_fit(X, y, classes=classes)
+        return super().partial_fit(X, y, monitor=monitor, classes=classes)
 
     def _is_multilabel(self, y):
         """

--- a/muffnn/mlp/tests/test_base.py
+++ b/muffnn/mlp/tests/test_base.py
@@ -1,0 +1,117 @@
+import unittest.mock
+
+import numpy as np
+import scipy.sparse
+import tensorflow as tf
+from tensorflow.python.ops import nn
+
+import civistext.mlp.base as base
+
+
+class TestEstimator(base.MLPBaseEstimator):
+
+    _input_indices = 'input_indices'
+    _input_values = 'input_values'
+    _input_shape = 'input_shape'
+    input_labels_ = 'input_labels'
+
+    def __init__(self, hidden_units=(256,), batch_size=64, n_epochs=5,
+                 dropout=None, activation=nn.relu, init_scale=0.1,
+                 random_state=None, monitor=None):
+        self.hidden_units = hidden_units
+        self.batch_size = batch_size
+        self.n_epochs = n_epochs
+        self.dropout = dropout
+        self.activation = activation
+        self.init_scale = init_scale
+        self.random_state = random_state
+        self.monitor = monitor
+
+    def _init_model_output(self, t, _):
+        self.input_labels_ = tf.placeholder(tf.int64, [None], "labels")
+        self.output_layer_ = tf.nn.softmax(t)
+        return t
+
+    def predict(*_, **__):
+        pass
+
+    def _init_model_objective_fn(self, t):
+        cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(
+            t, self.input_labels_)
+        self._obj_func = tf.reduce_mean(cross_entropy)
+
+def test_make_feed_dict_csr():
+    X = scipy.sparse.csr_matrix((
+        np.array([1, 2, 3, 4, 5, 6]),
+        (np.array([0, 0, 1, 2, 2, 2]), np.array([0, 2, 2, 0, 1, 2]))),
+        shape=(3, 3))
+    y = np.array([1, 2, 3])
+
+    clf = TestEstimator()
+    clf.is_sparse_ = True
+
+    feed_dict = clf._make_feed_dict(X, y)
+    assert_feed_dict_equals(feed_dict, X)
+    np.testing.assert_array_equal(feed_dict['input_labels'], y)
+
+
+def test_make_feed_dict_other():
+    X = scipy.sparse.coo_matrix((
+        np.array([1, 2, 3, 4, 5, 6]),
+        (np.array([0, 0, 1, 2, 2, 2]), np.array([0, 2, 2, 0, 1, 2]))),
+        shape=(3, 3))
+    y = np.array([1, 2, 3])
+
+    clf = TestEstimator()
+    clf.is_sparse_ = True
+
+    feed_dict = clf._make_feed_dict(X, y)
+    assert_feed_dict_equals(feed_dict, X)
+    np.testing.assert_array_equal(feed_dict['input_labels'], y)
+
+
+@unittest.mock.patch.object(base.tf, 'Session')
+def test_fit_monitor(mock_Session):
+    # Ensure that we loop through batches and epochs appropriately
+    # while respecting the monitor function's ability to cause
+    # early stopping.
+    mock_Session().run.return_value = (
+        unittest.mock.MagicMock(), unittest.mock.MagicMock())
+    mock_eval = unittest.mock.MagicMock(return_value=False)
+
+    X = np.reshape(np.arange(9), (3, 3))
+    y = np.arange(3)
+
+    clf = TestEstimator(n_epochs=10, batch_size=2)
+    clf.fit(X, y, monitor=mock_eval)
+    # two batches per epoch + an initialize variables call
+    assert mock_Session().run.call_count == 21
+    assert mock_eval.call_count == 10
+
+    mock_Session.reset_mock()
+    mock_eval.reset_mock()
+    clf = TestEstimator(n_epochs=10, batch_size=3)
+    clf.fit(X, y, monitor=mock_eval)
+    # one batch per epoch
+    assert mock_Session().run.call_count == 11
+    assert mock_eval.call_count == 10
+
+    mock_Session.reset_mock()
+    mock_eval.reset_mock()
+    mock_eval = unittest.mock.MagicMock(return_value=True)
+    clf = TestEstimator(n_epochs=10, batch_size=3)
+    clf.fit(X, y, monitor=mock_eval)
+    # Our monitor returns true, so it should only do one epoch
+    assert mock_Session().run.call_count == 2
+    assert mock_eval.call_count == 1
+
+
+def assert_feed_dict_equals(feed_dict, matrix):
+    """Ensure that the sparse matrix described by `feed_dict` represents
+    the same data as `matrix`.
+    """
+    indices = zip(*feed_dict['input_indices'])
+    result_matrix = scipy.sparse.bsr_matrix(
+        (feed_dict['input_values'], indices), shape=feed_dict['input_shape'])
+
+    np.testing.assert_array_equal(matrix.toarray(), result_matrix.toarray())

--- a/muffnn/mlp/tests/test_mlp_classifier.py
+++ b/muffnn/mlp/tests/test_mlp_classifier.py
@@ -29,9 +29,9 @@ X = [[-1, 0], [0, 1], [1, 1]]
 X_sp = sp.csr_matrix(X)
 Y1 = [0, 1, 1]
 Y2 = [2, 1, 0]
-Y_multilabel = np.array([[0, 1],
-                         [1, 1],
-                         [1, 0]])
+Y_multilabel = np.array([[0, 1, 0],
+                         [1, 1, 0],
+                         [1, 0, 1]])
 
 # The defaults kwargs don't work for tiny datasets like those in these tests.
 KWARGS = {"random_state": 0, "n_epochs": 100, "batch_size": 1}


### PR DESCRIPTION
This adds some PRs from the original private version of this code that didn't make it into the public version, by my mistake.

The changes are originally from @waltaskew.

* adds a monitor keyword argument to the MLP (e.g., for optional logging, checkpointing, early stopping)
* refactors the MLP sparse input to make it more efficient
* fixes multilabel classification