### PR TITLE
made dropout keep_prob keyword arg consistent with tensorflow

### DIFF
--- a/muffnn/autoencoder/autoencoder.py
+++ b/muffnn/autoencoder/autoencoder.py
@@ -38,8 +38,10 @@ class Autoencoder(TFPicklingBase, TransformerMixin, BaseEstimator):
     n_epochs : int, optional
         The number of epochs (iterations through the training data) when
         fitting.
-    dropout : float or None, optional
-        The dropout probability. If None, then dropout will not be used.
+    keep_prob : float, optional
+        The probability of keeping values in dropout. A value of 1.0 means that
+        dropout will not be used. cf. `TensorFlow documentation
+        <https://www.tensorflow.org/versions/r0.11/api_docs/python/nn.html#dropout>`
     hidden_activation : tensorflow graph operation, optional
         The activation function for the hidden layers and encoding layer.
         See `tensorflow.nn` for various options.
@@ -109,14 +111,14 @@ class Autoencoder(TFPicklingBase, TransformerMixin, BaseEstimator):
     """
 
     def __init__(self, hidden_units=(16,), batch_size=128, n_epochs=5,
-                 dropout=None, hidden_activation=tf.nn.sigmoid,
+                 keep_prob=1.0, hidden_activation=tf.nn.sigmoid,
                  output_activation=tf.nn.sigmoid, random_state=None,
                  learning_rate=1e-3, loss='mse', sigmoid_indices=None,
                  softmax_indices=None):
         self.hidden_units = hidden_units
         self.batch_size = batch_size
         self.n_epochs = n_epochs
-        self.dropout = dropout
+        self.keep_prob = keep_prob
         self.hidden_activation = hidden_activation
         self.output_activation = output_activation
         self.random_state = random_state
@@ -129,9 +131,9 @@ class Autoencoder(TFPicklingBase, TransformerMixin, BaseEstimator):
         """Initialize TF objects (needed before fitting or restoring)."""
 
         # A placeholder to control dropout for training vs. prediction.
-        self._dropout = tf.placeholder(dtype=tf.float32,
-                                       shape=(),
-                                       name="dropout")
+        self._keep_prob = tf.placeholder(dtype=tf.float32,
+                                         shape=(),
+                                         name="keep_prob")
 
         # Input values.
         self._input_values = tf.placeholder(tf.float32,
@@ -163,8 +165,7 @@ class Autoencoder(TFPicklingBase, TransformerMixin, BaseEstimator):
 
         # Fan in layers.
         for i, layer_sz in enumerate(self.hidden_units):
-            if self.dropout is not None:
-                t = tf.nn.dropout(t, keep_prob=1.0 - self._dropout)
+            t = tf.nn.dropout(t, keep_prob=self._keep_prob)
             t = affine(t, layer_sz, scope='layer_%d' % i)
             if self.hidden_activation is not None:
                 t = self.hidden_activation(t)
@@ -176,8 +177,7 @@ class Autoencoder(TFPicklingBase, TransformerMixin, BaseEstimator):
         second_layers \
             = list(self.hidden_units[::-1][1:]) + [self.input_layer_size_]
         for i, layer_sz in enumerate(second_layers):
-            if self.dropout is not None:
-                t = tf.nn.dropout(t, keep_prob=1.0 - self._dropout)
+            t = tf.nn.dropout(t, keep_prob=self._keep_prob)
             t = affine(t,
                        layer_sz,
                        scope='layer_%d' % (i + len(self.hidden_units)))
@@ -373,12 +373,8 @@ class Autoencoder(TFPicklingBase, TransformerMixin, BaseEstimator):
         else:
             feed_dict = {self._input_values: X}
 
-        if not training:
-            # If not training, fix the dropout to zero so keep_prob = 1.0.
-            feed_dict[self._dropout] = 0.0
-        else:
-            feed_dict[self._dropout] = \
-                self.dropout if self.dropout is not None else 0.0
+        # If not training, turn off dropout (i.e., set keep_prob = 1.0).
+        feed_dict[self._keep_prob] = self.keep_prob if training else 1.0
 
         feed_dict[self._sigmoid_msk] \
             = self._sigmoid_msk_values[0:X.shape[0], :]
@@ -413,7 +409,7 @@ class Autoencoder(TFPicklingBase, TransformerMixin, BaseEstimator):
         state.update(dict(hidden_activation=self.hidden_activation,
                           output_activation=self.output_activation,
                           batch_size=self.batch_size,
-                          dropout=self.dropout,
+                          keep_prob=self.keep_prob,
                           hidden_units=self.hidden_units,
                           random_state=self.random_state,
                           n_epochs=self.n_epochs,

--- a/muffnn/autoencoder/autoencoder.py
+++ b/muffnn/autoencoder/autoencoder.py
@@ -165,7 +165,8 @@ class Autoencoder(TFPicklingBase, TransformerMixin, BaseEstimator):
 
         # Fan in layers.
         for i, layer_sz in enumerate(self.hidden_units):
-            t = tf.nn.dropout(t, keep_prob=self._keep_prob)
+            if self.keep_prob != 1.0:
+                t = tf.nn.dropout(t, keep_prob=self._keep_prob)
             t = affine(t, layer_sz, scope='layer_%d' % i)
             if self.hidden_activation is not None:
                 t = self.hidden_activation(t)
@@ -177,7 +178,8 @@ class Autoencoder(TFPicklingBase, TransformerMixin, BaseEstimator):
         second_layers \
             = list(self.hidden_units[::-1][1:]) + [self.input_layer_size_]
         for i, layer_sz in enumerate(second_layers):
-            t = tf.nn.dropout(t, keep_prob=self._keep_prob)
+            if self.keep_prob != 1.0:
+                t = tf.nn.dropout(t, keep_prob=self._keep_prob)
             t = affine(t,
                        layer_sz,
                        scope='layer_%d' % (i + len(self.hidden_units)))

--- a/muffnn/autoencoder/tests/test_autoencoder.py
+++ b/muffnn/autoencoder/tests/test_autoencoder.py
@@ -84,7 +84,7 @@ def test_persistence():
                      n_epochs=1000,
                      random_state=4556,
                      learning_rate=1e-2,
-                     dropout=0.0)
+                     keep_prob=1.0)
     Xenc = ae.fit_transform(X)
 
     b = BytesIO()
@@ -103,14 +103,14 @@ def test_replicability():
                       n_epochs=1000,
                       random_state=4556,
                       learning_rate=1e-2,
-                      dropout=0.0)
+                      keep_prob=1.0)
     Xenc1 = ae1.fit_transform(X)
 
     ae2 = Autoencoder(hidden_units=(1,),
                       n_epochs=1000,
                       random_state=4556,
                       learning_rate=1e-2,
-                      dropout=0.0)
+                      keep_prob=1.0)
     Xenc2 = ae2.fit_transform(X)
 
     assert_array_almost_equal(Xenc1, Xenc2)
@@ -130,7 +130,7 @@ def test_refitting():
                      n_epochs=1000,
                      random_state=4556,
                      learning_rate=1e-2,
-                     dropout=0.0,
+                     keep_prob=1.0,
                      loss='cross-entropy')
     ae.fit(X)
     assert ae.input_layer_size_ == 4, ("Input layer is the wrong size for "
@@ -216,7 +216,7 @@ def test_errors_loss_output_activation():
 
 def _check_ae(max_score,
               hidden_units=(1,),
-              dropout=None,
+              keep_prob=1.0,
               learning_rate=1e-1,
               sparse_type=None,
               bin_inds=None,
@@ -301,7 +301,7 @@ def _check_ae(max_score,
                      n_epochs=n_epochs,
                      random_state=4556,
                      learning_rate=learning_rate,
-                     dropout=dropout,
+                     keep_prob=keep_prob,
                      loss=loss,
                      sigmoid_indices=bin_inds_to_use,
                      softmax_indices=cat_indices)
@@ -383,12 +383,12 @@ def test_mse_dropout():
     """Test the MSE loss w/ dropout."""
     ae_score_dropout = _check_ae(MSE_MAX_SCORE,
                                  hidden_units=(20, 20, 10, 10, 2),
-                                 dropout=0.05,
+                                 keep_prob=0.95,
                                  learning_rate=1e-3)
 
     ae_score_nodropout = _check_ae(MSE_MAX_SCORE,
                                    hidden_units=(20, 20, 10, 10, 2),
-                                   dropout=0.0,
+                                   keep_prob=1.0,
                                    learning_rate=1e-3)
 
     assert ae_score_nodropout < ae_score_dropout, ("MSE with dropout should "
@@ -420,7 +420,7 @@ def test_sigmoid_softmax_cross_entropy_loss_single_hidden_unit():
                          n_epochs=5000,
                          random_state=4556,
                          learning_rate=1e-1,
-                         dropout=0.0,
+                         keep_prob=1.0,
                          loss='cross-entropy',
                          output_activation=tf.nn.softmax,
                          sigmoid_indices=binary_indices)

--- a/muffnn/mlp/base.py
+++ b/muffnn/mlp/base.py
@@ -244,7 +244,8 @@ class MLPBaseEstimator(TFPicklingBase, BaseEstimator, metaclass=ABCMeta):
                 t = affine(t, layer_sz, input_size=self.input_layer_sz_,
                            scope='layer_%d' % i, sparse_input=True)
             else:
-                t = tf.nn.dropout(t, keep_prob=self._keep_prob)
+                if self.keep_prob != 1.0:
+                    t = tf.nn.dropout(t, keep_prob=self._keep_prob)
                 t = affine(t, layer_sz, scope='layer_%d' % i)
             t = t if self.activation is None else self.activation(t)
 

--- a/muffnn/mlp/mlp_classifier.py
+++ b/muffnn/mlp/mlp_classifier.py
@@ -99,7 +99,8 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
             t = affine(t, output_size, input_size=self.input_layer_sz_,
                        scope='output_layer', sparse_input=True)
         else:
-            t = tf.nn.dropout(t, keep_prob=self._keep_prob)
+            if self.keep_prob != 1.0:
+                t = tf.nn.dropout(t, keep_prob=self._keep_prob)
             t = affine(t, output_size, scope='output_layer')
 
         if self.multilabel_:

--- a/muffnn/mlp/mlp_classifier.py
+++ b/muffnn/mlp/mlp_classifier.py
@@ -38,8 +38,10 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
     n_epochs : int, optional
         The number of epochs (iterations through the training data) when
         fitting.
-    dropout : float or None, optional
-        The dropout probability.  If None, then dropout will not be used.
+    keep_prob : float, optional
+        The probability of keeping values in dropout. A value of 1.0 means that
+        dropout will not be used. cf. `TensorFlow documentation
+        <https://www.tensorflow.org/versions/r0.11/api_docs/python/nn.html#dropout>`
     activation : callable, optional
         The activation function.  See tensorflow.python.ops.nn.
     init_scale : float, optional
@@ -74,12 +76,12 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
     """
 
     def __init__(self, hidden_units=(256,), batch_size=64, n_epochs=5,
-                 dropout=None, activation=nn.relu, init_scale=0.1,
+                 keep_prob=1.0, activation=nn.relu, init_scale=0.1,
                  random_state=None):
         self.hidden_units = hidden_units
         self.batch_size = batch_size
         self.n_epochs = n_epochs
-        self.dropout = dropout
+        self.keep_prob = keep_prob
         self.activation = activation
         self.init_scale = init_scale
         self.random_state = random_state
@@ -97,7 +99,7 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
             t = affine(t, output_size, input_size=self.input_layer_sz_,
                        scope='output_layer', sparse_input=True)
         else:
-            t = tf.nn.dropout(t, keep_prob=self._dropout)
+            t = tf.nn.dropout(t, keep_prob=self._keep_prob)
             t = affine(t, output_size, scope='output_layer')
 
         if self.multilabel_:

--- a/muffnn/mlp/mlp_regressor.py
+++ b/muffnn/mlp/mlp_regressor.py
@@ -37,8 +37,10 @@ class MLPRegressor(MLPBaseEstimator, RegressorMixin):
     n_epochs : int, optional
         The number of epochs (iterations through the training data) when
         fitting.
-    dropout : float or None, optional
-        The dropout probability.  If None, then dropout will not be used.
+    keep_prob : float, optional
+        The probability of keeping values in dropout. A value of 1.0 means that
+        dropout will not be used. cf. `TensorFlow documentation
+        <https://www.tensorflow.org/versions/r0.11/api_docs/python/nn.html#dropout>`
     activation : callable, optional
         The activation function.  See tensorflow.python.ops.nn.
     init_scale : float, optional
@@ -77,12 +79,12 @@ class MLPRegressor(MLPBaseEstimator, RegressorMixin):
     """
 
     def __init__(self, hidden_units=(256,), batch_size=64, n_epochs=5,
-                 dropout=None, activation=nn.relu, init_scale=0.1,
+                 keep_prob=1.0, activation=nn.relu, init_scale=0.1,
                  random_state=None):
         self.hidden_units = hidden_units
         self.batch_size = batch_size
         self.n_epochs = n_epochs
-        self.dropout = dropout
+        self.keep_prob = keep_prob
         self.activation = activation
         self.init_scale = init_scale
         self.random_state = random_state
@@ -92,7 +94,7 @@ class MLPRegressor(MLPBaseEstimator, RegressorMixin):
             t = affine(t, 1, input_size=self.input_layer_sz_,
                        scope='output_layer', sparse_input=True)
         else:
-            t = tf.nn.dropout(t, keep_prob=self._dropout)
+            t = tf.nn.dropout(t, keep_prob=self._keep_prob)
             t = affine(t, 1, scope='output_layer')
 
         self.input_targets_ = tf.placeholder(tf.float32, [None], "targets")

--- a/muffnn/mlp/mlp_regressor.py
+++ b/muffnn/mlp/mlp_regressor.py
@@ -94,7 +94,8 @@ class MLPRegressor(MLPBaseEstimator, RegressorMixin):
             t = affine(t, 1, input_size=self.input_layer_sz_,
                        scope='output_layer', sparse_input=True)
         else:
-            t = tf.nn.dropout(t, keep_prob=self._keep_prob)
+            if self.keep_prob != 1.0:
+                t = tf.nn.dropout(t, keep_prob=self._keep_prob)
             t = affine(t, 1, scope='output_layer')
 
         self.input_targets_ = tf.placeholder(tf.float32, [None], "targets")

--- a/muffnn/mlp/tests/test_base.py
+++ b/muffnn/mlp/tests/test_base.py
@@ -14,15 +14,15 @@ class TestEstimator(base.MLPBaseEstimator):
     _input_values = 'input_values'
     _input_shape = 'input_shape'
     input_targets_ = 'input_targets'
-    _dropout = 1.0
+    _keep_prob = 1.0
 
     def __init__(self, hidden_units=(256,), batch_size=64, n_epochs=5,
-                 dropout=None, activation=nn.relu, init_scale=0.1,
+                 keep_prob=1.0, activation=nn.relu, init_scale=0.1,
                  random_state=None, monitor=None):
         self.hidden_units = hidden_units
         self.batch_size = batch_size
         self.n_epochs = n_epochs
-        self.dropout = dropout
+        self.keep_prob = keep_prob
         self.activation = activation
         self.init_scale = init_scale
         self.random_state = random_state

--- a/muffnn/mlp/tests/test_mlp_regressor.py
+++ b/muffnn/mlp/tests/test_mlp_regressor.py
@@ -43,10 +43,11 @@ def check_predictions(est, X, y):
 # the toy example tests that have only a handful of examples.
 class MLPRegressorManyEpochs(MLPRegressor):
     def __init__(self, hidden_units=(256,), batch_size=64,
-                 dropout=None, activation=nn.relu, init_scale=0.1):
+                 keep_prob=1.0, activation=nn.relu, init_scale=0.1):
         super().__init__(hidden_units=hidden_units, batch_size=batch_size,
-                         n_epochs=100, dropout=dropout, activation=activation,
-                         init_scale=init_scale, random_state=42)
+                         n_epochs=100, keep_prob=keep_prob,
+                         activation=activation, init_scale=init_scale,
+                         random_state=42)
 
 
 def test_check_estimator():
@@ -69,7 +70,7 @@ def test_replicability():
     rng.shuffle(ind)
     X_diabetes, y_diabetes = X_diabetes[ind], y_diabetes[ind]
 
-    clf = MLPRegressor(dropout=0.9, random_state=42, n_epochs=100)
+    clf = MLPRegressor(keep_prob=0.9, random_state=42, n_epochs=100)
     target = y_diabetes
     # Just predict on the training set, for simplicity.
     pred1 = clf.fit(X_diabetes, target).predict(X_diabetes)


### PR DESCRIPTION
closes #6 (applies to both the MLP and autoencoder).

This changes the `dropout` keyword argument to `keep_prob` to be consistent internally and consistent with tensorflow.