### PR TITLE
Update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,6 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
 COPY . /src/muffnn
 RUN conda env create -f /src/muffnn/environment.yml -q
 RUN conda install flake8 pytest pip nose -n muffnn && \
-    pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.11.0rc2-cp35-cp35m-linux_x86_64.whl
+    pip install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.11.0-cp35-cp35m-linux_x86_64.whl
 RUN cd /src/muffnn && \
     pip install .

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip install .
 Google provides TensorFlow pip wheels for different OSs and architectures.
 See [this page](https://www.tensorflow.org/versions/r0.10/get_started/os_setup.html#pip-installation)
 for more details.  For Python 3.5 on 64-bit Linux with no GPU, set
-`export TF_BINARY_URL=https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.10.0rc0-cp35-cp35m-linux_x86_64.whl`.
+`export TF_BINARY_URL=https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.11.0-cp35-cp35m-linux_x86_64.whl`
 
 For development, a few additional dependencies are needed:
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: muffnn
 dependencies:
-  - python=3.5
-  - numpy=1.11.1
+  - python=3.5.2
+  - numpy=1.11.2
   - scipy=0.18.0
-  - scikit-learn=0.17.1
+  - scikit-learn=0.18.1

--- a/muffnn/autoencoder/autoencoder.py
+++ b/muffnn/autoencoder/autoencoder.py
@@ -11,7 +11,7 @@ import scipy.sparse as sp
 
 from sklearn.base import TransformerMixin, BaseEstimator
 from sklearn.utils import check_array, check_random_state
-from sklearn.utils.validation import NotFittedError
+from sklearn.exceptions import NotFittedError
 
 from muffnn.core import TFPicklingBase, affine
 

--- a/muffnn/mlp/base.py
+++ b/muffnn/mlp/base.py
@@ -19,7 +19,7 @@ from sklearn.base import BaseEstimator
 from sklearn.utils import (check_array, check_random_state, check_X_y,
                            DataConversionWarning)
 
-from sklearn.utils.validation import NotFittedError
+from sklearn.exceptions import NotFittedError
 
 import tensorflow as tf
 from tensorflow.python.framework.ops import Graph


### PR DESCRIPTION
This updated dependencies to the latest stable versions.  closes #17 

- update sklearn to 0.18.1 to maintain compatibility with packages that require it. There are a couple import changes as a result.
- TensorFlow 0.11.0 stable instead of RC2 (there's a RC for 0.12, but I figured using a stable version would be better)
- switch python version to version with patch number (3.5.2 instead of 3.5) for replicability
- update numpy patch version because I don't see a reason not to