### PR TITLE
ENH add ability to use relu to autoencoder

### DIFF
--- a/muffnn/autoencoder/autoencoder.py
+++ b/muffnn/autoencoder/autoencoder.py
@@ -170,10 +170,10 @@ class Autoencoder(TFPicklingBase, TransformerMixin, BaseEstimator):
                 t = tf.nn.dropout(t, keep_prob=self._keep_prob)
             t = affine(t, layer_sz, scope='layer_%d' % i)
             if (self.hidden_activation is not None and
-                i < len(self.hidden_units) - 1):
+                    i < len(self.hidden_units) - 1):
                 t = self.hidden_activation(t)
             if (self.encoding_activation is not None and
-                        i == len(self.hidden_units) - 1):
+                    i == len(self.hidden_units) - 1):
                 t = self.encoding_activation(t)
 
         # Encoded values.

--- a/muffnn/autoencoder/autoencoder.py
+++ b/muffnn/autoencoder/autoencoder.py
@@ -45,12 +45,15 @@ class Autoencoder(TFPicklingBase, TransformerMixin, BaseEstimator):
     hidden_activation : tensorflow graph operation, optional
         The activation function for the hidden layers.
         See `tensorflow.nn` for various options.
+        None is equivalent to a linear activation.
     encoding_activation : tensorflow graph operation, optional
         The activation function for the encoding layer.
         See `tensorflow.nn` for various options.
+        None is equivalent to a linear activation.
     output_activation : tensorflow graph operation, optional
         The activation function for the output layer.
         See `tensorflow.nn` for various options.
+        None is equivalent to a linear activation.
         If `loss` is set to 'cross-entropy', then only
         `tensorflow.nn.sigmoid` or `tensorflow.nn.softmax` are valid
         options.

--- a/muffnn/autoencoder/tests/test_autoencoder.py
+++ b/muffnn/autoencoder/tests/test_autoencoder.py
@@ -23,7 +23,8 @@ from muffnn import Autoencoder
 _LOGGER = logging.getLogger(__name__)
 iris = load_iris()
 
-LEARNING_RATE = 2e-3
+# Learning rate for most tests, changed in some places for convergence.
+DEFAULT_LEARNING_RATE = 2e-3
 
 
 def _cross_entropy(ytrue, ypred):
@@ -226,7 +227,7 @@ def test_mse_sigmoid_activations():
     ae = Autoencoder(hidden_units=(3, 2,),
                      n_epochs=7500,
                      random_state=4556,
-                     learning_rate=LEARNING_RATE,
+                     learning_rate=DEFAULT_LEARNING_RATE,
                      keep_prob=1.0,
                      hidden_activation=tf.nn.sigmoid,
                      encoding_activation=tf.nn.sigmoid,
@@ -287,7 +288,7 @@ def test_sigmoid_softmax_cross_entropy_loss():
         ae = Autoencoder(hidden_units=(2,),
                          n_epochs=7500,
                          random_state=4556,
-                         learning_rate=LEARNING_RATE,
+                         learning_rate=DEFAULT_LEARNING_RATE,
                          keep_prob=1.0,
                          loss='cross-entropy',
                          output_activation=tf.nn.softmax,
@@ -426,7 +427,7 @@ def _check_ae(max_score,
         output_activation = None
 
     if learning_rate is None:
-        learning_rate = LEARNING_RATE
+        learning_rate = DEFAULT_LEARNING_RATE
 
     ae = Autoencoder(hidden_units=hidden_units,
                      n_epochs=n_epochs,
@@ -572,7 +573,9 @@ def test_sparse_inputs():
             sparse_type=sparse_type,
             cat_inds=range(4),
             n_epochs=1000,
-            learning_rate=5e-3))
+            learning_rate=5e-3  # Using a higher learning rate
+                                # here for convergence.
+            ))
 
     # All scores should be equal.
     for score in scores:


### PR DESCRIPTION
This PR adds the ability to use relu activations for the autoencoder.

Changes in the tests include 
1. now use `relu` for the activation
2. renamed a bunch of them
3. changed the size of the hidden layers from 1 unit to 2 in many cases
4. made sure learning rates were set properly to get good results

Closes #21 