### PR TITLE
ENH upgrade to Tf 1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh && \
     /bin/bash /Miniconda3-4.2.12-Linux-x86_64.sh -b -p /opt/conda && \
     rm Miniconda3-4.2.12-Linux-x86_64.sh && \
-    /opt/conda/bin/conda install --yes conda==4.2.12
+    /opt/conda/bin/conda install --yes conda==4.2.12 && \
+    echo "conda ==4.2.12" > /opt/conda/conda-meta/pinned
 
 COPY . /src/muffnn
 RUN conda env create -f /src/muffnn/environment.yml -q

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,8 @@
 name: muffnn
 dependencies:
   - python=3.5.2
-  - numpy=1.11.2
-  - scipy=0.18.0
+  - numpy=1.11.3
+  - scipy=0.18.1
   - scikit-learn=0.18.1
   - pip:
-    - tensorflow==0.12.1
+    - tensorflow==1.0.0

--- a/muffnn/mlp/base.py
+++ b/muffnn/mlp/base.py
@@ -133,7 +133,7 @@ class MLPBaseEstimator(TFPicklingBase, BaseEstimator, metaclass=ABCMeta):
                 self._build_tf_graph()
 
                 # Train model parameters.
-                self._session.run(tf.initialize_all_variables())
+                self._session.run(tf.global_variables_initializer())
 
             # Set an attributed to mark this as at least partially fitted.
             self._is_fitted = True

--- a/muffnn/mlp/mlp_classifier.py
+++ b/muffnn/mlp/mlp_classifier.py
@@ -120,17 +120,17 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
     def _init_model_objective_fn(self, t):
         if self.multilabel_:
             cross_entropy = tf.nn.sigmoid_cross_entropy_with_logits(
-                t, tf.cast(self.input_targets_, np.float32))
+                logits=t, labels=tf.cast(self.input_targets_, np.float32))
             y_finite = tf.equal(self.input_targets_, -1)
             self._obj_func = tf.reduce_mean(
-                tf.select(y_finite, self._zeros, cross_entropy))
+                tf.where(y_finite, self._zeros, cross_entropy))
         elif self.n_classes_ > 2:
             cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(
-                t, self.input_targets_)
+                logits=t, labels=self.input_targets_)
             self._obj_func = tf.reduce_mean(cross_entropy)
         else:
             cross_entropy = tf.nn.sigmoid_cross_entropy_with_logits(
-                t, tf.cast(self.input_targets_, np.float32))
+                logits=t, labels=tf.cast(self.input_targets_, np.float32))
             self._obj_func = tf.reduce_mean(cross_entropy)
 
     def partial_fit(self, X, y, monitor=None, classes=None):

--- a/muffnn/mlp/tests/test_base.py
+++ b/muffnn/mlp/tests/test_base.py
@@ -40,7 +40,7 @@ class TestEstimator(base.MLPBaseEstimator):
 
     def _init_model_objective_fn(self, t):
         cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(
-            t, self.input_targets_)
+            logits=t, labels=self.input_targets_)
         self._obj_func = tf.reduce_mean(cross_entropy)
 
 


### PR DESCRIPTION
This PR moves us to TF 1.0. 

See this page for upgrade instructions https://www.tensorflow.org/install/migration.

I have run the code through their upgrade script and not found any errors. 

Closes #29