### PR TITLE
MAINT bump version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/) 
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [1.0.0] - 2017-02-23
+
+### Changed
+
+- Upgraded to TensorFlow 1.0.0
 
 ## [0.2.0] - 2016-11-29
 
@@ -13,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   stopping, checkpointing, etc.
 - Add top-level base class for pickling TensorFlow models.
 - Add partial fitting functionality for the MLP.
+- Add support for missing labels for MLPClassifier.
 
 ### Changed
 
@@ -24,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- `LabelEncoder` in the MLPClassifier is pickled properly
 - Fix multilabel classification, which was broken previously.
 
 ## [0.1.0] - 2016-08-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Upgraded to TensorFlow 1.0.0
+- Upgraded to TensorFlow 1.0.0.
 
 ## [0.2.0] - 2016-11-29
 
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   stopping, checkpointing, etc.
 - Add top-level base class for pickling TensorFlow models.
 - Add partial fitting functionality for the MLP.
-- Add support for missing labels for MLPClassifier.
+- Add support for missing labels during multilabel classification.
 
 ### Changed
 
@@ -27,11 +27,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Stop adding dropout nodes to MLP graphs if `keep_prob` is 1.
 - Change `dropout` keyword argument to `keep_prob` for consistency with
   TensorFlow.
-- Updated dependencies (notably, scikit-learn and TensorFlow)
+- Updated dependencies (notably, scikit-learn and TensorFlow).
 
 ### Fixed
 
-- `LabelEncoder` in the MLPClassifier is pickled properly
+- `LabelEncoder` in the MLPClassifier is pickled properly.
 - Fix multilabel classification, which was broken previously.
 
 ## [0.1.0] - 2016-08-25

--- a/README.md
+++ b/README.md
@@ -1,26 +1,27 @@
 # Introduction
 
 This project provides multilayer perceptron predictive models, implemented
-using [TensorFlow](https://www.tensorflow.org/) and following the 
+using [TensorFlow](https://www.tensorflow.org/) and following the
 [scikit-learn](http://scikit-learn.org)
 [Predictor API](http://scikit-learn.org/stable/developers/contributing.html#apis-of-scikit-learn-objects).
 
 # Installation
 
-Installation with `conda` and `pip` is recommended:
+Installation with `pip` is recommended:
+
+```bash
+pip install muffnn
+```
+
+You can also create a `conda` environment with `muffnn` installed
 
 ```bash
 conda env create -f environment.yml
 source activate muffnn
-# See comment below about TF_BINARY_URL.
-pip install $TF_BINARY_URL
-pip install .
 ```
 
 Google provides TensorFlow pip wheels for different OSs and architectures.
-See [this page](https://www.tensorflow.org/versions/r0.10/get_started/os_setup.html#pip-installation)
-for more details.  For Python 3.5 on 64-bit Linux with no GPU, set
-`export TF_BINARY_URL=https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.11.0-cp35-cp35m-linux_x86_64.whl`
+See [this page](https://www.tensorflow.org/install/) for more details.
 
 For development, a few additional dependencies are needed:
 

--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ See `LICENSE.txt` for details.
 * [Walt Askew](https://github.com/waltaskew/)
 * [Matt Becker](https://github.com/beckermr/)
 * [Bill Lattner](https://github.com/wlattner/)
+* [Sam Weiss](https://github.com/samcarlos)

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ Installation with `pip` is recommended:
 pip install muffnn
 ```
 
-You can also create a `conda` environment with `muffnn` installed
+You can also create a `conda` environment:
 
 ```bash
 conda env create -f environment.yml
 source activate muffnn
+pip install muffnn
 ```
 
 Google provides TensorFlow pip wheels for different OSs and architectures.

--- a/environment.yml
+++ b/environment.yml
@@ -6,4 +6,3 @@ dependencies:
   - scikit-learn=0.18.1
   - pip:
     - tensorflow==1.0.0
-    - muffnn==1.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,4 @@ dependencies:
   - scikit-learn=0.18.1
   - pip:
     - tensorflow==1.0.0
+    - muffnn==1.0.0

--- a/muffnn/version.py
+++ b/muffnn/version.py
@@ -1,2 +1,2 @@
 # Note that this file will be executed by setup.py.
-__version__ = '0.2.0'
+__version__ = '1.0.0'


### PR DESCRIPTION
Due to backwards incompatible changes in TensorFlow, it makes sense to bump the major version here to 1.0.0. I updated the docs to reflect the easier install procedure. Once this PR is merged, I will tag 1.0.0 and then push a new version to pypi.