### PR TITLE
BUG add `MANIFEST.in` to fix packaging bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.1] - 2017-03-27
+
+### Fixed
+
+- Added `MANIFEST.in` to fix python packaging bug.
+
 ## [1.1.0] - 2017-03-27
 
 ### Added

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include CHANGELOG.md
+include LICENSE.txt
+include README.md

--- a/muffnn/version.py
+++ b/muffnn/version.py
@@ -1,2 +1,2 @@
 # Note that this file will be executed by setup.py.
-__version__ = '1.1.0'
+__version__ = '1.1.1'


### PR DESCRIPTION
This PR fixes the packaging bug and bumps the version to `v1.1.1`.

Closes #41 