### PR TITLE
BUG make solver keyword args a dict so we can grid search over it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.2] - ????-??-??
+
+### Fixed
+
+- Fixed bug in grid search over solver settings.
+
 ## [1.1.1] - 2017-03-27
 
 ### Fixed

--- a/muffnn/mlp/base.py
+++ b/muffnn/mlp/base.py
@@ -255,8 +255,9 @@ class MLPBaseEstimator(TFPicklingBase, BaseEstimator, metaclass=ABCMeta):
         t = self._init_model_output(t)
         self._init_model_objective_fn(t)
 
-        self._train_step \
-            = self.solver(**self.solver_kwargs).minimize(self._obj_func)
+        self._train_step = self.solver(
+            **self.solver_kwargs if self.solver_kwargs else {}).minimize(
+            self._obj_func)
 
     def _make_feed_dict(self, X, y=None):
         # Make the dictionary mapping tensor placeholders to input data.

--- a/muffnn/mlp/mlp_classifier.py
+++ b/muffnn/mlp/mlp_classifier.py
@@ -55,7 +55,7 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
         used.
     solver : a subclass of `tf.train.Optimizer`, optional
         The solver to use to minimize the loss.
-    **solver_kwargs : optional
+    solver_kwargs : dict, optional
         Additional keyword arguments to pass to `solver` upon construction.
         See the TensorFlow documentation for possible options. Typically,
         one would want to set the `learning_rate`.
@@ -82,7 +82,7 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
     def __init__(self, hidden_units=(256,), batch_size=64, n_epochs=5,
                  keep_prob=1.0, activation=nn.relu, init_scale=0.1,
                  random_state=None, solver=tf.train.AdamOptimizer,
-                 **solver_kwargs):
+                 solver_kwargs):
         self.hidden_units = hidden_units
         self.batch_size = batch_size
         self.n_epochs = n_epochs

--- a/muffnn/mlp/mlp_classifier.py
+++ b/muffnn/mlp/mlp_classifier.py
@@ -82,7 +82,7 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
     def __init__(self, hidden_units=(256,), batch_size=64, n_epochs=5,
                  keep_prob=1.0, activation=nn.relu, init_scale=0.1,
                  random_state=None, solver=tf.train.AdamOptimizer,
-                 solver_kwargs):
+                 solver_kwargs=None):
         self.hidden_units = hidden_units
         self.batch_size = batch_size
         self.n_epochs = n_epochs

--- a/muffnn/mlp/mlp_regressor.py
+++ b/muffnn/mlp/mlp_regressor.py
@@ -83,7 +83,7 @@ class MLPRegressor(MLPBaseEstimator, RegressorMixin):
     def __init__(self, hidden_units=(256,), batch_size=64, n_epochs=5,
                  keep_prob=1.0, activation=nn.relu, init_scale=0.1,
                  random_state=None, solver=tf.train.AdamOptimizer,
-                 solver_kwargs):
+                 solver_kwargs=None):
         self.hidden_units = hidden_units
         self.batch_size = batch_size
         self.n_epochs = n_epochs

--- a/muffnn/mlp/mlp_regressor.py
+++ b/muffnn/mlp/mlp_regressor.py
@@ -54,7 +54,7 @@ class MLPRegressor(MLPBaseEstimator, RegressorMixin):
         used.
     solver : a subclass of `tf.train.Optimizer`, optional
         The solver to use to minimize the loss.
-    **solver_kwargs : optional
+    solver_kwargs : dict, optional
         Additional keyword arguments to pass to `solver` upon construction.
         See the TensorFlow documentation for possible options. Typically,
         one would want to set the `learning_rate`.
@@ -83,7 +83,7 @@ class MLPRegressor(MLPBaseEstimator, RegressorMixin):
     def __init__(self, hidden_units=(256,), batch_size=64, n_epochs=5,
                  keep_prob=1.0, activation=nn.relu, init_scale=0.1,
                  random_state=None, solver=tf.train.AdamOptimizer,
-                 **solver_kwargs):
+                 solver_kwargs):
         self.hidden_units = hidden_units
         self.batch_size = batch_size
         self.n_epochs = n_epochs

--- a/muffnn/mlp/tests/test_base.py
+++ b/muffnn/mlp/tests/test_base.py
@@ -21,7 +21,7 @@ class SimpleTestEstimator(base.MLPBaseEstimator):
     def __init__(self, hidden_units=(256,), batch_size=64, n_epochs=5,
                  keep_prob=1.0, activation=nn.relu, init_scale=0.1,
                  random_state=None, monitor=None,
-                 solver=tf.train.AdamOptimizer, solver_kwargs):
+                 solver=tf.train.AdamOptimizer, solver_kwargs=None):
         self.hidden_units = hidden_units
         self.batch_size = batch_size
         self.n_epochs = n_epochs

--- a/muffnn/mlp/tests/test_base.py
+++ b/muffnn/mlp/tests/test_base.py
@@ -21,7 +21,7 @@ class SimpleTestEstimator(base.MLPBaseEstimator):
     def __init__(self, hidden_units=(256,), batch_size=64, n_epochs=5,
                  keep_prob=1.0, activation=nn.relu, init_scale=0.1,
                  random_state=None, monitor=None,
-                 solver=tf.train.AdamOptimizer, **solver_kwargs):
+                 solver=tf.train.AdamOptimizer, solver_kwargs):
         self.hidden_units = hidden_units
         self.batch_size = batch_size
         self.n_epochs = n_epochs


### PR DESCRIPTION
Closes #42 

One issue is that one has to generate the grid search parameters themselves for this to work. So if you want to grid search over the learning rate and something else, you will need to explicitly list all of the combinations of the two options IIUIC.

The "scikit" way would be to list each arg explicitly with a suitable default. However this approach has serious maintenance and definitional issues. @mheilman, your proposed solution seems like a good middle ground.