### PR TITLE
BUG make sure classes attribute for multilabel problems is set properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed bug in grid search over solver settings.
+- Fixed bug in `classes_` attribute for multilabel MLP problems. 
 
 ## [1.1.1] - 2017-03-27
 

--- a/muffnn/mlp/mlp_classifier.py
+++ b/muffnn/mlp/mlp_classifier.py
@@ -204,7 +204,7 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
 
         if self.multilabel_:
             self._enc = None
-            self.classes_ = np.array([0, 1])
+            self.classes_ = np.arange(y.shape[1])
             self.n_classes_ = y.shape[1]
         else:
             self._enc = LabelEncoder().fit(y)

--- a/muffnn/mlp/tests/test_mlp_classifier.py
+++ b/muffnn/mlp/tests/test_mlp_classifier.py
@@ -63,6 +63,8 @@ def test_check_estimator():
 def check_multilabel_predictions(clf, X, y):
     predicted = clf.fit(X, y).predict(X)
 
+    assert_array_equal(clf.classes_, np.arange(y.shape[1]))
+
     assert_equal(predicted.shape, y.shape)
     assert_array_equal(predicted, y)
 
@@ -80,6 +82,8 @@ def check_multilabel_predictions_na(clf, X, y):
     predicted[is_na] = 0
     y_temp = y.copy()
     y_temp[is_na] = 0
+
+    assert_array_equal(clf.classes_, np.arange(y.shape[1]))
 
     assert_equal(predicted.shape, y_temp.shape)
     assert_array_equal(predicted, y_temp)


### PR DESCRIPTION
We are using the OvR multilabel conventions for scikit. In this case, the `classes_` attribute needs to be an array of length the number of labels.