### PR TITLE
BUG hide import from tf.contrib to make overall imports faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Hid slow import of `tf.contrib` (#54).
+
 ## [1.1.2] - 2017-05-22
 
 ### Changed

--- a/muffnn/fm/fm_classifier.py
+++ b/muffnn/fm/fm_classifier.py
@@ -5,7 +5,6 @@ import re
 import scipy.sparse as sp
 import numpy as np
 import tensorflow as tf
-from tensorflow.contrib.opt import ScipyOptimizerInterface
 
 from sklearn.base import ClassifierMixin, BaseEstimator
 from sklearn.utils import check_X_y, check_array, check_random_state
@@ -141,6 +140,8 @@ class FMClassifier(TFPicklingBase, ClassifierMixin, BaseEstimator):
                 += self.lambda_beta * tf.reduce_sum(tf.square(self._beta))
 
         if isinstance(self.solver, str):
+            from tensorflow.contrib.opt import ScipyOptimizerInterface
+
             self._train_step = ScipyOptimizerInterface(
                 self._obj_func,
                 method=self.solver,


### PR DESCRIPTION
This PR hides an import from tf.contrib to make the import of the package faster. 

This is related to https://github.com/tensorflow/tensorflow/issues/11829.

Closes #55 