### PR TITLE
In Which We Illustrate a Wacky Bug

### DIFF
--- a/muffnn/mlp/base.py
+++ b/muffnn/mlp/base.py
@@ -272,6 +272,9 @@ class MLPBaseEstimator(TFPicklingBase, BaseEstimator):
             if self._transform_layer_index == i:
                 self._transform_layer = t
 
+        self._snakes = \
+            tf.placeholder(np.float32, [None], 'snakes')
+
         # The output layer and objective function depend on the model
         # (e.g., classification vs regression).
         t = self._init_model_output(t)


### PR DESCRIPTION
Illustrating a bug I don't know how to explain yet.
Adding an unused placeholder before the call to `_init_model_output` causes one of the `mlp_regressor` tests to fail. I don't know how to explain this one yet.
This had me convinced I had a bug in some code I was writing -- tracking this down took a minute.

Snakes, @mheilman 