### PR TITLE
add prediction_gradient method for MLPs

### DIFF
--- a/muffnn/mlp/base.py
+++ b/muffnn/mlp/base.py
@@ -310,7 +310,8 @@ class MLPBaseEstimator(TFPicklingBase, BaseEstimator):
         else:
             output_shape = self.output_layer_.get_shape()
             # Note: tf.gradients returns a list of gradients dy/dx, one per
-            # given x.
+            # input tensor x. In other words,
+            # [ tensor(n_features x n_gradients) ].
             if len(output_shape) == 1:
                 self._prediction_gradient = tf.gradients(
                     t, self._input_values)[0]

--- a/muffnn/mlp/base.py
+++ b/muffnn/mlp/base.py
@@ -301,6 +301,26 @@ class MLPBaseEstimator(TFPicklingBase, BaseEstimator):
         if self._transform_layer_index == -1:
             self._transform_layer = t
 
+        # Prediction gradients (e.g., for analyzing the importance of features)
+        # We use the top layer before the output activation function
+        # (e.g., softmax, sigmoid) following
+        # https://arxiv.org/pdf/1312.6034.pdf
+        if self.is_sparse_:
+            self._prediction_gradient = None
+        else:
+            output_shape = self.output_layer_.get_shape()
+            if len(output_shape) == 1:
+                self._prediction_gradient = tf.gradients(
+                    t, self._input_values)[0]
+            else:
+                # According to the tf.gradients documentation, it looks like
+                # we have to compute gradients separately for each output
+                # dimension and then stack them for multiclass/label data.
+                self._prediction_gradient = tf.stack([
+                    tf.gradients(t[:, i], self._input_values)[0]
+                    for i in range(self.output_layer_.get_shape()[1])
+                ], axis=1)
+
         self._sample_weight = \
             tf.placeholder(np.float32, [None], "sample_weight")
 
@@ -347,15 +367,7 @@ class MLPBaseEstimator(TFPicklingBase, BaseEstimator):
         if not self._is_fitted:
             raise NotFittedError("Call fit before prediction")
 
-        X = check_array(X, accept_sparse=['csr', 'dok', 'lil', 'csc', 'coo'])
-
-        if self.is_sparse_:
-            # For sparse input, make the input a CSR matrix since it can be
-            # indexed by row.
-            X = X.tocsr() if sp.issparse(X) else sp.csr_matrix(X)
-        elif sp.issparse(X):
-            # Convert sparse input to dense.
-            X = X.todense().A
+        X = self._check_X(X)
 
         # Make predictions in batches.
         pred_batches = []
@@ -371,6 +383,19 @@ class MLPBaseEstimator(TFPicklingBase, BaseEstimator):
                     self._session.run(self.output_layer_, feed_dict=feed_dict))
         y_pred = np.concatenate(pred_batches)
         return y_pred
+
+    def _check_X(self, X):
+        X = check_array(X, accept_sparse=['csr', 'dok', 'lil', 'csc', 'coo'])
+
+        if self.is_sparse_:
+            # For sparse input, make the input a CSR matrix since it can be
+            # indexed by row.
+            X = X.tocsr() if sp.issparse(X) else sp.csr_matrix(X)
+        elif sp.issparse(X):
+            # Convert sparse input to dense.
+            X = X.todense().A
+
+        return X
 
     @abstractmethod
     def predict(self, X):
@@ -392,15 +417,7 @@ class MLPBaseEstimator(TFPicklingBase, BaseEstimator):
         if not self._is_fitted:
             raise NotFittedError("Call fit before transform")
 
-        X = check_array(X, accept_sparse=['csr', 'dok', 'lil', 'csc', 'coo'])
-
-        if self.is_sparse_:
-            # For sparse input, make the input a CSR matrix since it can be
-            # indexed by row.
-            X = X.tocsr() if sp.issparse(X) else sp.csr_matrix(X)
-        elif sp.issparse(X):
-            # Convert sparse input to dense.
-            X = X.todense().A
+        X = self._check_X(X)
 
         # Make predictions in batches.
         embed_batches = []
@@ -444,6 +461,60 @@ class MLPBaseEstimator(TFPicklingBase, BaseEstimator):
             else:
                 # fit method of arity 2 (supervised transformation)
                 return self.fit(X, y, **fit_params).transform(X)
+
+    def prediction_gradient(self, X):
+        """Compute the prediction gradient with respect to the given inputs.
+
+        Parameters
+        ----------
+        X : numpy array of shape [n_samples, n_features]
+            Examples to compute feature importance based on.
+
+        Returns
+        -------
+        numpy array
+            Array of gradients for each example. For single-class or regression
+            problems, this will be of shape [n_samples, n_features].
+            For multilabel or multiclass problems, it will be of shape
+            [n_samples, n_classes, n_features].
+
+        Notes
+        -----
+        This is related to what is sometimes referred to as
+        "sensitivity analysis" (e.g., Simonyan et al., ICLR 2014). There are
+        more complex methods for computing the effects of input features on
+        outputs (e.g., SHAP, LIME, layerwise relevance propagation, DeepLIFT),
+        but using prediction gradients is fast and simple, and also has
+        theoretical connections to other methods.  See, e.g., Shrikumar (2017,
+        https://arxiv.org/abs/1704.02685) for discussion and further
+        references. This function can also be used for the "gradient x input"
+        technique described by Shrikumar (2017).
+        """
+        if not self._is_fitted:
+            raise NotFittedError("Call fit first.")
+
+        if self.is_sparse_:
+            raise NotImplementedError("Not implemented for sparse inputs.")
+
+        X = self._check_X(X)
+
+        # Compute gradients in batches.
+        imprt_vals = []
+        start_idx = 0
+        n_examples = X.shape[0]
+        with self.graph_.as_default():
+            while start_idx < n_examples:
+                X_batch = \
+                    X[start_idx:min(start_idx + self.batch_size, n_examples)]
+                feed_dict = self._make_feed_dict(X_batch)
+                start_idx += self.batch_size
+                imprt_vals.append(
+                    self._session.run(self._prediction_gradient,
+                                      feed_dict=feed_dict))
+
+        imprt_vals = np.concatenate(imprt_vals)
+
+        return imprt_vals
 
 
 def _sparse_matrix_data(X):

--- a/muffnn/mlp/tests/test_mlp_classifier.py
+++ b/muffnn/mlp/tests/test_mlp_classifier.py
@@ -357,3 +357,44 @@ def test_sample_weight(make_dataset_func, dataset_kwargs):
         lambda: MLPClassifier(n_epochs=30, random_state=42,
                               keep_prob=0.8, hidden_units=(128,))
     )
+
+
+def test_prediction_gradient():
+    """Test computation of prediction gradients."""
+    # Binary classification
+    n_classes = 1
+    mlp = MLPClassifier(n_epochs=100, random_state=42, hidden_units=(5,))
+    X, y = make_classification(
+        n_samples=1000, n_informative=n_classes, n_redundant=0,
+        n_classes=n_classes, n_clusters_per_class=1, shuffle=False)
+    mlp.fit(X, y)
+    grad = mlp.prediction_gradient(X)
+    grad_means = grad.mean(axis=0)
+    assert grad.shape == X.shape
+    # Check that only the informative feature has a large gradient.
+    assert np.abs(grad_means[0]) > 1.
+    for m in grad_means[1:]:
+        assert np.abs(m) < 0.5
+
+    # Multiclass classification: here, we'll just check that it runs and that
+    # the output is the right shape.
+    n_classes = 5
+    X, y = make_classification(
+        n_samples=1000, n_classes=n_classes, n_informative=n_classes,
+        n_redundant=0, shuffle=False, n_clusters_per_class=1)
+    mlp.fit(X, y)
+    grad = mlp.prediction_gradient(X)
+    assert grad.shape == (X.shape[0], n_classes, X.shape[1])
+
+    # Multilabel binary classification.
+    X, y = make_multilabel_classification(
+        n_samples=1000, random_state=42, n_classes=n_classes)
+    mlp.fit(X, y)
+    grad = mlp.prediction_gradient(X)
+    assert grad.shape == (X.shape[0], n_classes, X.shape[1])
+
+    # Raise an exception for sparse inputs, which are not yet supported.
+    X_sp = sp.csr_matrix(X)
+    mlp.fit(X_sp, y)
+    with pytest.raises(NotImplementedError):
+        mlp.prediction_gradient(X_sp)

--- a/muffnn/mlp/tests/test_mlp_classifier.py
+++ b/muffnn/mlp/tests/test_mlp_classifier.py
@@ -365,13 +365,15 @@ def test_prediction_gradient():
     n_classes = 1
     mlp = MLPClassifier(n_epochs=100, random_state=42, hidden_units=(5,))
     X, y = make_classification(
-        n_samples=1000, n_informative=n_classes, n_redundant=0,
+        n_samples=1000, n_features=20, n_informative=n_classes, n_redundant=0,
         n_classes=n_classes, n_clusters_per_class=1, shuffle=False)
     mlp.fit(X, y)
     grad = mlp.prediction_gradient(X)
     grad_means = grad.mean(axis=0)
     assert grad.shape == X.shape
     # Check that only the informative feature has a large gradient.
+    # The values of 1 and 0.5 here are somewhat arbitrary but should serve as
+    # a regression test if nothing else.
     assert np.abs(grad_means[0]) > 1.
     for m in grad_means[1:]:
         assert np.abs(m) < 0.5
@@ -380,8 +382,9 @@ def test_prediction_gradient():
     # the output is the right shape.
     n_classes = 5
     X, y = make_classification(
-        n_samples=1000, n_classes=n_classes, n_informative=n_classes,
-        n_redundant=0, shuffle=False, n_clusters_per_class=1)
+        n_samples=1000, n_features=20, n_informative=n_classes,
+        n_redundant=0, n_classes=n_classes, n_clusters_per_class=1,
+        shuffle=False)
     mlp.fit(X, y)
     grad = mlp.prediction_gradient(X)
     assert grad.shape == (X.shape[0], n_classes, X.shape[1])


### PR DESCRIPTION
This adds a method to facilitate the interpretation of MLP model predictions.  Specifically, it enables one to compute the gradient of the final output layer (pre-sigmoid logits for logistic regression, etc.) with respect to the input features.

I'm leaving sparse inputs to a future PR.  Also, I have some notebooks illustrating the method on toy datasets that might be worth adding.