### PR TITLE
Fixed ValueError for type of target in MLPClassifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Exposed `muffnn.__version__`.
 - Fixed bug in `FMClassifier` where it failed for predicting one example.
-- Fixed ValueError for type of target in MLPClassifier (#90).
+- Fixed ValueError for type of target in MLPClassifier and FMClassifier (#90).
 
 ## [2.1.0] - 2018-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Exposed `muffnn.__version__`.
 - Fixed bug in `FMClassifier` where it failed for predicting one example.
+- Fixed ValueError for type of target in MLPClassifier (#90).
 
 ## [2.1.0] - 2018-02-12
 

--- a/muffnn/fm/fm_classifier.py
+++ b/muffnn/fm/fm_classifier.py
@@ -273,7 +273,7 @@ class FMClassifier(TFPicklingBase, ClassifierMixin, BaseEstimator):
         if target_type not in ['binary', 'multiclass']:
             # Raise an error, as in
             # sklearn.utils.multiclass.check_classification_targets.
-            raise ValueError("Unknown label type: %r" % y)
+            raise ValueError("Unknown label type: %s" % target_type)
 
         # Initialize the model if it hasn't been already by a previous call.
         if not self._is_fitted:

--- a/muffnn/mlp/mlp_classifier.py
+++ b/muffnn/mlp/mlp_classifier.py
@@ -217,7 +217,7 @@ class MLPClassifier(MLPBaseEstimator, ClassifierMixin):
         else:
             # Raise an error, as in
             # sklearn.utils.multiclass.check_classification_targets.
-            raise ValueError("Unknown label type: %r" % y)
+            raise ValueError("Unknown label type: %s" % target_type)
 
     def _fit_targets(self, y, classes=None):
         self.multilabel_ = self._is_multilabel(y)


### PR DESCRIPTION
A very minor thing: we were printing `y` instead of `target_type` when raising an exception about the type of `y`.