### PR TITLE
MAINT Update dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 notifications:
     email: false
 language: python
@@ -6,10 +7,10 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
 install:
     - pip install --upgrade pip setuptools
     - pip install -r dev-requirements.txt
-    - pip install -r requirements.txt
     - pip install -e .
 script:
     - flake8 muffnn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- Updated tests for changes in new versions of `scipy`, `scikit-learn`, and `flake8` (#98).
+- Increased required version of `tensorflow` due to published CVEs in older versions (#98).
+
 ## [2.2.0] - 2018-06-07
 
 ### Added

--- a/muffnn/autoencoder/tests/test_autoencoder.py
+++ b/muffnn/autoencoder/tests/test_autoencoder.py
@@ -8,6 +8,11 @@ import logging
 import pprint
 from io import BytesIO
 import pickle
+import sys
+try:
+    from unittest import mock
+except ImportError:
+    mock = None
 
 import pytest
 import numpy as np
@@ -98,7 +103,15 @@ class AutoencoderManyEpochs(Autoencoder):
 
 def test_check_estimator():
     """Check adherence to Estimator API."""
-    check_estimator(AutoencoderManyEpochs)
+    if sys.version_info.major == 3 and sys.version_info.minor == 7:
+        # Starting in Tensorflow 1.14 and Python 3.7, there's one module
+        # with a `0` in the __warningregistry__. Scikit-learn tries to clear
+        # this dictionary in its tests.
+        name = 'tensorboard.compat.tensorflow_stub.pywrap_tensorflow'
+        with mock.patch.object(sys.modules[name], '__warningregistry__', {}):
+            check_estimator(AutoencoderManyEpochs)
+    else:
+        check_estimator(AutoencoderManyEpochs)
 
 
 def test_persistence():

--- a/muffnn/autoencoder/tests/test_autoencoder.py
+++ b/muffnn/autoencoder/tests/test_autoencoder.py
@@ -75,9 +75,30 @@ def _cross_entropy(ytrue, ypred):
     return np.sum(ce, axis=1)
 
 
+class AutoencoderManyEpochs(Autoencoder):
+    """Increase default model capacity and number of epochs so that
+    the default Estimator will pass scikit-learn's sanity checks.
+    """
+    def __init__(self, hidden_units=(256,), batch_size=128, n_epochs=300,
+                 keep_prob=1.0, hidden_activation=tf.nn.relu,
+                 encoding_activation=None,
+                 output_activation=None, random_state=None,
+                 learning_rate=1e-3, loss='mse', sigmoid_indices=None,
+                 softmax_indices=None):
+        super(AutoencoderManyEpochs, self).__init__(
+            hidden_units=hidden_units, batch_size=batch_size,
+            n_epochs=n_epochs, keep_prob=keep_prob,
+            hidden_activation=hidden_activation,
+            encoding_activation=encoding_activation,
+            output_activation=output_activation, random_state=random_state,
+            learning_rate=learning_rate, loss=loss,
+            sigmoid_indices=sigmoid_indices, softmax_indices=softmax_indices,
+        )
+
+
 def test_check_estimator():
     """Check adherence to Estimator API."""
-    check_estimator(Autoencoder)
+    check_estimator(AutoencoderManyEpochs)
 
 
 def test_persistence():

--- a/muffnn/fm/tests/test_fm_classifier.py
+++ b/muffnn/fm/tests/test_fm_classifier.py
@@ -9,6 +9,11 @@ from __future__ import division
 
 from io import BytesIO
 import pickle
+import sys
+try:
+    from unittest import mock
+except ImportError:
+    mock = None
 
 import numpy as np
 import pytest
@@ -115,7 +120,15 @@ def test_make_feed_dict_sparse():
 
 def test_check_estimator():
     """Check adherence to Estimator API."""
-    check_estimator(FMClassifierLBFGSB)
+    if sys.version_info.major == 3 and sys.version_info.minor == 7:
+        # Starting in Tensorflow 1.14 and Python 3.7, there's one module
+        # with a `0` in the __warningregistry__. Scikit-learn tries to clear
+        # this dictionary in its tests.
+        name = 'tensorboard.compat.tensorflow_stub.pywrap_tensorflow'
+        with mock.patch.object(sys.modules[name], '__warningregistry__', {}):
+            check_estimator(FMClassifierLBFGSB)
+    else:
+        check_estimator(FMClassifierLBFGSB)
 
 
 def test_predict_lbfgsb():

--- a/muffnn/fm/tests/test_fm_classifier.py
+++ b/muffnn/fm/tests/test_fm_classifier.py
@@ -13,7 +13,10 @@ import pickle
 import numpy as np
 import pytest
 import scipy.sparse as sp
-from scipy.misc import logsumexp
+try:
+    from scipy.misc import logsumexp
+except ImportError:
+    from scipy.special import logsumexp
 from sklearn.datasets import load_iris, make_classification
 from sklearn.linear_model.tests.test_logistic import check_predictions
 from sklearn.utils.estimator_checks import check_estimator

--- a/muffnn/fm/tests/test_fm_regressor.py
+++ b/muffnn/fm/tests/test_fm_regressor.py
@@ -9,6 +9,11 @@ from __future__ import division
 
 from io import BytesIO
 import pickle
+import sys
+try:
+    from unittest import mock
+except ImportError:
+    mock = None
 
 import numpy as np
 import pytest
@@ -119,7 +124,15 @@ def test_make_feed_dict_sparse():
 
 def test_check_estimator():
     """Check adherence to Estimator API."""
-    check_estimator(FMRegressorLBFGSB)
+    if sys.version_info.major == 3 and sys.version_info.minor == 7:
+        # Starting in Tensorflow 1.14 and Python 3.7, there's one module
+        # with a `0` in the __warningregistry__. Scikit-learn tries to clear
+        # this dictionary in its tests.
+        name = 'tensorboard.compat.tensorflow_stub.pywrap_tensorflow'
+        with mock.patch.object(sys.modules[name], '__warningregistry__', {}):
+            check_estimator(FMRegressorLBFGSB)
+    else:
+        check_estimator(FMRegressorLBFGSB)
 
 
 def test_predict_lbfgsb():

--- a/muffnn/mlp/base.py
+++ b/muffnn/mlp/base.py
@@ -446,30 +446,30 @@ class MLPBaseEstimator(TFPicklingBase, BaseEstimator):
         return embedding
 
     def fit_transform(self, X, y=None, **fit_params):
-            """Fit to data, then transform it.
+        """Fit to data, then transform it.
 
-            Fits transformer to X and y with optional parameters fit_params
-            and returns a transformed version of X.
+        Fits transformer to X and y with optional parameters fit_params
+        and returns a transformed version of X.
 
-            Parameters
-            ----------
-            X : numpy array of shape [n_samples, n_features]
-                Training set.
-            y : numpy array of shape [n_samples]
-                Target values.
-            Returns
-            -------
-            X_new : numpy array of shape [n_samples, n_features_new]
-                Transformed array.
-            """
-            # non-optimized default implementation; override when a better
-            # method is possible for a given clustering algorithm
-            if y is None:
-                # fit method of arity 1 (unsupervised transformation)
-                return self.fit(X, **fit_params).transform(X)
-            else:
-                # fit method of arity 2 (supervised transformation)
-                return self.fit(X, y, **fit_params).transform(X)
+        Parameters
+        ----------
+        X : numpy array of shape [n_samples, n_features]
+            Training set.
+        y : numpy array of shape [n_samples]
+            Target values.
+        Returns
+        -------
+        X_new : numpy array of shape [n_samples, n_features_new]
+            Transformed array.
+        """
+        # non-optimized default implementation; override when a better
+        # method is possible for a given clustering algorithm
+        if y is None:
+            # fit method of arity 1 (unsupervised transformation)
+            return self.fit(X, **fit_params).transform(X)
+        else:
+            # fit method of arity 2 (supervised transformation)
+            return self.fit(X, y, **fit_params).transform(X)
 
     def prediction_gradient(self, X):
         """Compute the prediction gradient with respect to the given inputs.

--- a/muffnn/mlp/tests/test_mlp_classifier.py
+++ b/muffnn/mlp/tests/test_mlp_classifier.py
@@ -9,6 +9,11 @@ from __future__ import division
 
 from io import BytesIO
 import pickle
+import sys
+try:
+    from unittest import mock
+except ImportError:
+    mock = None
 
 import six
 import numpy as np
@@ -76,7 +81,15 @@ class MLPClassifierManyEpochs(MLPClassifier):
 
 def test_check_estimator():
     """Check adherence to Estimator API."""
-    check_estimator(MLPClassifierManyEpochs)
+    if sys.version_info.major == 3 and sys.version_info.minor == 7:
+        # Starting in Tensorflow 1.14 and Python 3.7, there's one module
+        # with a `0` in the __warningregistry__. Scikit-learn tries to clear
+        # this dictionary in its tests.
+        name = 'tensorboard.compat.tensorflow_stub.pywrap_tensorflow'
+        with mock.patch.object(sys.modules[name], '__warningregistry__', {}):
+            check_estimator(MLPClassifierManyEpochs)
+    else:
+        check_estimator(MLPClassifierManyEpochs)
 
 
 def check_multilabel_predictions(clf, X, y):

--- a/muffnn/mlp/tests/test_mlp_regressor.py
+++ b/muffnn/mlp/tests/test_mlp_regressor.py
@@ -4,6 +4,12 @@ Tests for MLP Regressor
 from __future__ import print_function
 from __future__ import division
 
+import sys
+try:
+    from unittest import mock
+except ImportError:
+    mock = None
+
 import numpy as np
 import pytest
 from sklearn.utils.testing import \
@@ -68,7 +74,15 @@ class MLPRegressorFewerParams(MLPRegressor):
 
 def test_check_estimator():
     """Check adherence to Estimator API."""
-    check_estimator(MLPRegressorFewerParams)
+    if sys.version_info.major == 3 and sys.version_info.minor == 7:
+        # Starting in Tensorflow 1.14 and Python 3.7, there's one module
+        # with a `0` in the __warningregistry__. Scikit-learn tries to clear
+        # this dictionary in its tests.
+        name = 'tensorboard.compat.tensorflow_stub.pywrap_tensorflow'
+        with mock.patch.object(sys.modules[name], '__warningregistry__', {}):
+            check_estimator(MLPRegressorFewerParams)
+    else:
+        check_estimator(MLPRegressorFewerParams)
 
 
 def test_predict():

--- a/muffnn/mlp/tests/test_mlp_regressor.py
+++ b/muffnn/mlp/tests/test_mlp_regressor.py
@@ -53,21 +53,22 @@ def test_sample_weight():
     )
 
 
-# Make a subclass that has its default number of epochs high enough not to fail
-# the toy example tests that have only a handful of examples.
-class MLPRegressorManyEpochs(MLPRegressor):
-    def __init__(self, hidden_units=(256,), batch_size=64,
-                 keep_prob=1.0, activation=nn.relu):
-        super(MLPRegressorManyEpochs, self).__init__(
+# Make a subclass that has no `solver` parameter. The scikit-learn
+# `check_estimator` has a check which fails with a class as a default.
+class MLPRegressorFewerParams(MLPRegressor):
+    def __init__(self, hidden_units=(256,), batch_size=64, n_epochs=5,
+                 keep_prob=1.0, activation=nn.relu,
+                 random_state=None):
+        super(MLPRegressorFewerParams, self).__init__(
             hidden_units=hidden_units, batch_size=batch_size,
-            n_epochs=50, keep_prob=keep_prob,
+            n_epochs=n_epochs, keep_prob=keep_prob,
             activation=activation,
-            random_state=42)
+            random_state=random_state)
 
 
 def test_check_estimator():
     """Check adherence to Estimator API."""
-    check_estimator(MLPRegressorManyEpochs)
+    check_estimator(MLPRegressorFewerParams)
 
 
 def test_predict():

--- a/muffnn/mlp/tests/test_mlp_regressor.py
+++ b/muffnn/mlp/tests/test_mlp_regressor.py
@@ -60,7 +60,7 @@ class MLPRegressorManyEpochs(MLPRegressor):
                  keep_prob=1.0, activation=nn.relu):
         super(MLPRegressorManyEpochs, self).__init__(
             hidden_units=hidden_units, batch_size=batch_size,
-            n_epochs=100, keep_prob=keep_prob,
+            n_epochs=50, keep_prob=keep_prob,
             activation=activation,
             random_state=42)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ numpy~=1.14
 scipy~=1.0
 scikit-learn~=0.19
 six~=1.10
-tensorflow>=1.12.1
+tensorflow>=1.12.1,<2
 mock==2.0.0 ; python_version < '3.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ numpy~=1.14
 scipy~=1.0
 scikit-learn~=0.19
 six~=1.10
-tensorflow~=1.4
+tensorflow>=1.12.1
 mock==2.0.0 ; python_version < '3.0'

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setup(
     install_requires=['numpy',
                       'scipy',
                       'scikit-learn~=0.19',
-                      'tensorflow~=1.4']
+                      'tensorflow>=1.12.1']
 )

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setup(
     install_requires=['numpy',
                       'scipy',
                       'scikit-learn~=0.19',
-                      'tensorflow>=1.12.1']
+                      'tensorflow>=1.12.1,<2']
 )


### PR DESCRIPTION
This PR increases the `tensorflow` version requirement to addresses the following security vulnerabilities in tensorflow: CVE-2018-7576, CVE-2018-7575, CVE-2019-9635, CVE-2018-7577, CVE-2018-10055, CVE-2018-7574. They are of severity: 1x CRITICAL, 3x HIGH, 2x MEDIUM. (From PR #97 .) Aside from increasing the required `tensorflow` version and adding Python 3.7 testing, the rest of this PR is all modifications to the testing code to get tests to pass. Failures seem to be due to changes in `scikit-learn`, `scipy`, and `flake8`.