### PR TITLE
update TF version, remove py3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ notifications:
     email: false
 language: python
 python:
-    - "3.5"
     - "3.6"
     - "3.7"
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [2.3.2] - 2020-11-18
+
+### Changed
+
+- Increase minimum version of `tensorflow` to v1.15.4 to fix the security vulnerability reported in https://github.com/advisories/GHSA-4g9f-63rx-5cw4 (#105)
+- Set more specific `scikit-learn` version requirements to avoid incompatibilities and test failures (#105)
+
+### Removed
+- Remove Python 3.5 support (#105)
+
 ## [2.3.1] - 2020-04-06
 
 ### Fixed

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ models implemented in `TensorFlow <https://www.tensorflow.org/>`__
 Installation
 ============
 
-This package currently supports Python 3.5, 3.6, and 3.7.
+This package currently supports Python 3.6 and 3.7.
 
 Installation with ``pip`` is recommended:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy~=1.14
 scipy~=1.0
-scikit-learn>=0.19
-tensorflow>=1.15.2,<2
+scikit-learn>=0.20.0,<0.23.0
+tensorflow>=1.15.4,<2

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,11 @@ from setuptools import find_packages, setup
 
 THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 
-_VERSION = '2.3.1'
+_VERSION = '2.3.2'
 
 CLASSIFIERS = [
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3 :: Only',
@@ -28,7 +27,7 @@ setup(
     license="BSD-3",
     install_requires=['numpy',
                       'scipy',
-                      'scikit-learn>=0.19',
-                      'tensorflow>=1.15.2,<2'],
+                      'scikit-learn>=0.20.0,<0.23.0',
+                      'tensorflow>=1.15.4,<2'],
     classifiers=CLASSIFIERS
 )


### PR DESCRIPTION
This updates the minimum TF version, per https://github.com/advisories/GHSA-4g9f-63rx-5cw4.

It also removes Python 3.5 support and sets more specific scikit-learn version requirements to avoid test failures and incompatibilities.